### PR TITLE
Implied docs now exported to JSON

### DIFF
--- a/official/static.rkt
+++ b/official/static.rkt
@@ -99,6 +99,7 @@
                 'versions versions-ht
                 'ring (hash-ref ht 'ring 2)
                 'dependencies (hash-ref ht 'dependencies empty)
+                'implies (hash-ref ht 'implies empty)
                 'modules (hash-ref ht 'modules empty)
                 'conflicts
                 (hash-ref ht 'conflicts


### PR DESCRIPTION
This pull request edits the `all-pkgs.json` file generated by the package index so that each package contains a list of package names implied by that package, corresponding with the `'implies` field in the package's `info.rkt`. 

The additional information provided by this change can be consumed by the `racket-pkg-website` HTML renderer to make a smarter table layout. The immediate, intended use of this information is to edit the package table so that package which keep their docs in a separate package will not complain about missing docs. (see: tonyg/racket-pkg-website#49).