### PR TITLE
Simplify setup and add heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ Requires the following packages to be installed:
  - `git://github.com/samth/bcrypt.rkt`
     - which in turn depends on `dynext-lib`
 
+## Running
+
+Run the dynamic server via `main.rkt`. Provide the `--config` file to
+specify a module that exports `config` as a hash table with symbol
+keys to configure the server. Alternatively, run one of the modules in
+`official/configs/`; those modules are also useful as configuration
+examples.
+
+To initialize the set of served packages, use `raco pkg catalog-copy`
+to copy an existing catalog to directory form, and then move the `pkg`
+directory in the catalog copy to be *root*`/pkgs` (where *root* is the
+server's root directory).
+
 ## Configuration
 
 Common configuration keys:
@@ -35,37 +48,29 @@ Common configuration keys:
     - `users.new-path` - path; defaults to *root*`/users.new`.
       Directory in which to hold user records, one file per user.
 
-    - `github-client_id` - string; defaults to the contents of the
-      file at *root*`/client_id`. Should be a Github client ID string
-      (hex; twenty characters long, i.e. 10 bytes of data,
-      hex-encoded)
-
-    - `github-client_secret` - string; defaults to the contents of the
-      file at *root*`/client_secret`. Should be a Github client secret
-      string (hex; forty characters long, i.e. 20 bytes of data,
-      hex-encoded)
-
     - `cache-path` - path; defaults to *root*`/cache`. Names a
       directory where files `summary.rktd` and `summary.rktd.etag`
       will be created.
 
-	- `pkgs-path` - path; defaults to *root*`/pkgs`. Names a directory
+    - `pkgs-path` - path; defaults to *root*`/pkgs`. Names a directory
       where one file of package information for each package in the
       catalog will be stored.
 
- - `s3-config` - path; defaults to the contents of the environment
-   variable `S3CFG_PLT`, if it is defined; otherwise, to the file
-   `.s3cfg-plt` in the user's home directory (usually `$HOME`). The
-   file at this location should be a configuration file for `s3cmd`;
-   see also the configuration key `s3cmd-path` below.
+    - `github-client_id` (obsolete) - string #f; defaults to the contents of the
+      file at *root*`/client_id`, if it exists. Should be a Github client ID string
+      (hex; twenty characters long, i.e. 10 bytes of data,
+      hex-encoded), used only if package downloaing is forced to use the
+      GitHub API by setting the `PLT_USE_GITHUB_API` environment variable
+
+    - `github-client_secret` (obsolete) - string or #f; defaults to the contents of the
+      file at *root*`/client_secret`, if it exists. Should be a Github client secret
+      string (hex; forty characters long, i.e. 20 bytes of data,
+      hex-encoded), used only when `github-client_id` is used
 
  - `s3-bucket` - string; defaults to the contents of the environment
    variable `S3_BUCKET`, if it is defined; otherwise, to
-   `pkgs.racket-lang.org`.
-
- - `s3cmd-path` - path; defaults to the contents of the environment
-   variable `S3CMD`, if it is defined; otherwise, to the full path to
-   the `s3cmd` executable on the system executable path.
+   `test.racket-lang.org`. AWS credentials are found by the `s3`
+   package, typically from `~/.aws-keys`.
 
 Configuration keys used by `dynamic.rkt`:
 
@@ -83,6 +88,9 @@ Configuration keys used by `dynamic.rkt`:
 
  - `port` - number; defaults to `9004`. Port on which the backend site
    will be served (N.B. via HTTPS).
+
+ - `ssl?` - boolean; ; defaults to `#t`. A true value serves HTTPS and
+    requires *root*/`server-cert.pem` and *root*/`private-key.pem`.
 
 Configuration keys used by `static.rkt`:
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Common configuration keys:
    `test.racket-lang.org`. AWS credentials are found by the `s3`
    package, typically from `~/.aws-keys`.
 
+ - `beat-s3-bucket` - string or #f; defaults to #f. A bucket name for
+   regsitering heartbeats, or #f to disable heartbeats.
+
 Configuration keys used by `dynamic.rkt`:
 
  - `redirect-to-static-proc` - function from HTTP request to HTTP
@@ -92,6 +95,9 @@ Configuration keys used by `dynamic.rkt`:
  - `ssl?` - boolean; ; defaults to `#t`. A true value serves HTTPS and
     requires *root*/`server-cert.pem` and *root*/`private-key.pem`.
 
+ - `beat-update-task-name` - string; defaults to "pkgd-update". A task
+   name for heartbeats after updating information for all packages.
+
 Configuration keys used by `static.rkt`:
 
  - `atom-self-link` - string; defaults to
@@ -110,3 +116,6 @@ Configuration keys used by `static.rkt`:
    package name and a format template-string from
    `atom-package-url-format-string`, which in turn defaults to
    `http://pkg.racket-lang.org/#[~a]`.
+
+ - `beat-upload-task-name` - string; defaults to "pkgd-upload". A task
+   name for heartbeats after uploading information for all packages.

--- a/info.rkt
+++ b/info.rkt
@@ -6,4 +6,5 @@
 (define test-responsibles '((all jay)))
 (define deps '("racket-lib"
                "base"
-               "bcrypt"))
+               "bcrypt"
+               "s3-sync"))

--- a/info.rkt
+++ b/info.rkt
@@ -6,5 +6,10 @@
 (define test-responsibles '((all jay)))
 (define deps '("racket-lib"
                "base"
+               "compatibility-lib"
+               "net-lib"
+               "web-server-lib"
                "bcrypt"
-               "s3-sync"))
+               "s3-sync"
+               "plt-service-monitor"))
+(define build-deps '("rackunit-lib"))

--- a/official/beat-update.sh
+++ b/official/beat-update.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec racket -l- plt-service-monitor/beat heartbeat.racket-lang.org pkgd-update

--- a/official/common.rkt
+++ b/official/common.rkt
@@ -8,6 +8,7 @@
          racket/string
          web-server/http/id-cookie
          pkg/private/stage
+         plt-service-monitor/beat
          "config.rkt")
 
 ;; This f o f^-1 is applied because it throws an error if file is not
@@ -160,6 +161,11 @@
                                   ;; To avoid accidentally changing the live data,
                                   ;; we use "test" (instead of "pkgo") by default
                                   "test.racket-lang.org")))
+
+(define beat-s3-bucket (get-config beat-s3-bucket #f))
+(define (heartbeat task)
+  (when beat-s3-bucket
+    (beat beat-s3-bucket task)))
 
 (provide (all-defined-out))
 (provide (all-from-out "config.rkt"))

--- a/official/configs/live.rkt
+++ b/official/configs/live.rkt
@@ -12,6 +12,8 @@
             'atom-package-url-format-string "https://pkgs.racket-lang.org/package/~a"
             's3-bucket "pkgo.racket-lang.org"
 
+            'beat-s3-bucket "heartbeat.racket-lang.org"
+
             ;; 'atom-package-url-format-string "http://pkg.racket-lang.org/package/~a"
             ;; 's3-bucket "pkgn.racket-lang.org"
             ))

--- a/official/dynamic.rkt
+++ b/official/dynamic.rkt
@@ -468,6 +468,7 @@
 
 (define (go)
   (define port (get-config port 9004))
+  (define ssl? (get-config ssl? #t))
   (log! "launching on port ~v" port)
   (signal-static! empty)
   (thread
@@ -486,9 +487,9 @@
    ;; this will help?
    #:connection-close? #t
    #:listen-ip #f
-   #:ssl? #t
-   #:ssl-cert (build-path root "server-cert.pem")
-   #:ssl-key (build-path root "private-key.pem")
+   #:ssl? ssl?
+   #:ssl-cert (and ssl? (build-path root "server-cert.pem"))
+   #:ssl-key (and ssl? (build-path root "private-key.pem"))
    #:extra-files-paths empty
    #:servlet-regexp #rx""
    #:port port))

--- a/official/main.rkt
+++ b/official/main.rkt
@@ -10,3 +10,15 @@
 (define (main [configuration (hash)])
   (config configuration)
   ((dynamic-require (build-path here "dynamic.rkt") 'go)))
+
+(module+ main
+  (require racket/cmdline)
+  (define configuration (hash))
+  (command-line
+   #:once-each
+   ["--config" file "Require `config` from module <file>"
+               (set! configuration
+                     (dynamic-require `(file ,file) 'config))]
+   #:args ()
+   (void))
+  (main configuration))

--- a/official/static.rkt
+++ b/official/static.rkt
@@ -13,6 +13,7 @@
          racket/list
          racket/path
          racket/promise
+         plt-service-monitor/beat
          "../basic/main.rkt"
          "common.rkt"
          "notify.rkt"
@@ -40,6 +41,7 @@
     (hasheq 'regexp (object-name r))]
    [x
     (error 'convert-to-json "~e" x)]))
+
 (define convert-to-json-key
   (match-lambda
    [(? string? s)
@@ -475,7 +477,8 @@
   (define changed-pkgs (generate-static pkgs))
   (signal-s3! changed-pkgs))
 (define (run-static! pkgs)
-  (run! do-static pkgs))
+  (run! do-static pkgs)
+  (heartbeat (get-config beat-upload-task-name "pkgd-upload")))
 (define run-sema (make-semaphore 1))
 (define (signal-static! pkgs)
   (safe-run! run-sema (λ () (run-static! pkgs))))

--- a/official/update.rkt
+++ b/official/update.rkt
@@ -148,7 +148,7 @@
 (define (run-update! pkgs beat?)
   (run! do-update! pkgs)
   (when beat?
-    (system* (path->string (build-path src "beat-update.sh")))))
+    (heartbeat (get-config beat-update-task-name "pkgd-update"))))
 (define run-sema (make-semaphore 1))
 (define (signal-update!* pkgs beat?)
   (safe-run! run-sema (λ () (run-update! pkgs beat?))))


### PR DESCRIPTION
The first patch makes running the server a little easier by removing some external dependencies, making it easier to configure a server externally, and adding a little more documentation. There are new Racket package dependencies, including `s3-sync`.

The second patch changes the way the heartbeat registration is configured: a configuration needs `beat-s3-bucket` to enable heartbeats. When heartbeats are enabled, a new one is added for the upload action (alongside the one for the update action).