### PR TITLE
disallow package names that differ only in case

### DIFF
--- a/official/modify-example.rktl
+++ b/official/modify-example.rktl
@@ -1,0 +1,5 @@
+#hasheq((pkg . "tester")
+        (name . "newly-renamed-tester")
+        (description . "a apckage that doesn't exist")
+        (source . "/tmp/tester")
+        (tags . ("none")))

--- a/official/modify.rkt
+++ b/official/modify.rkt
@@ -1,0 +1,41 @@
+#lang racket/base
+(require racket/list
+         net/url
+         racket/port
+         net/base64
+         json)
+
+(define (upload! the-email the-password the-url the-post)
+  (displayln the-email)
+  (println the-post)
+  (define bs
+    (call/input-url the-url
+                    (λ (url)
+                      (post-pure-port the-url
+                                      (jsexpr->bytes the-post)
+                                      ;; Adding an `Authorization` header lets this
+                                      ;; tool be used for "/api/package/modify-all", too
+                                      (list (string-append
+                                             "Authorization: Basic "
+                                             (bytes->string/utf-8
+                                              (base64-encode (string->bytes/utf-8
+                                                              (string-append
+                                                               the-email
+                                                               ":"
+                                                               the-password))
+                                                             #""))))))
+                    (lambda (p) (begin0 (port->bytes p) (close-input-port p)))))
+  (define v (port->string (open-input-bytes bs)))
+  (displayln v)
+  v)
+
+(module+ main
+  (require racket/cmdline)
+  (command-line #:program "upload"
+                #:args (email password [urlstr "https://pkgd.racket-lang.org/api/package/modify"])
+                (if (upload! email
+                             password
+                             (string->url urlstr)
+                             (read (current-input-port)))
+                  (exit 0)
+                  (exit 1))))


### PR DESCRIPTION
Avoid problems for case-sensitive filesystems by disallowing the creation of package names that differ only in case.