### PR TITLE
Fix package removal

### DIFF
--- a/official/common.rkt
+++ b/official/common.rkt
@@ -62,6 +62,9 @@
   (sort (map path->string (directory-list pkgs-path))
         string-ci<=?))
 
+(define (package-exists? pkg-name)
+  (file-exists? (build-path^ pkgs-path pkg-name)))
+
 (define (read-package-info pkg-name)
   (with-handlers ([exn:fail?
                    (λ (x)
@@ -72,7 +75,7 @@
     (define p
       (build-path^ pkgs-path pkg-name))
     (define v
-      (if (file-exists? p)
+      (if (package-exists? pkg-name)
           (file->value p)
           (hasheq)))
     (define ht

--- a/official/update.rkt
+++ b/official/update.rkt
@@ -16,8 +16,14 @@
   (update-checksums #t pkgs))
 
 (define (update-checksums force? pkgs)
-  (filter (curry update-checksum force?) pkgs))
+  (filter (λ (pkg-name)
+            (cond
+              [(package-exists? pkg-name)
+               (update-checksum force? pkg-name)]
+              [else (log! "update-checksums: invariant broken; ~a doesn't exist" pkg-name)]))
+          pkgs))
 
+;; precondition: pkg-name must exist
 (define (update-checksum force? pkg-name)
   (log! "update-checksum ~v ~v" force? pkg-name)
   (with-handlers

--- a/official/update.rkt
+++ b/official/update.rkt
@@ -20,7 +20,9 @@
             (cond
               [(package-exists? pkg-name)
                (update-checksum force? pkg-name)]
-              [else (log! "update-checksums: invariant broken; ~a doesn't exist" pkg-name)]))
+              [else (log! "update-checksums: invariant broken; ~a doesn't exist" pkg-name)
+                    ;; considered not update
+                    #f]))
           pkgs))
 
 ;; precondition: pkg-name must exist


### PR DESCRIPTION
When pkg-name doesn't exist, an attempt to update the checksum
will inadvertently create the package with empty source and author.
This PR "fixes" the problem. However, the actual problem
(calling update-checksums with stale list of packages) is still
unidentified.

**Please test the code and review it carefully before merging.** I did not know how to test the code and how to set up for an environment to run the code.

Toward fixing https://github.com/racket/racket-pkg-website/issues/60