### PR TITLE
Add run-time dependencies and license to the hash table

### DIFF
--- a/official/static.rkt
+++ b/official/static.rkt
@@ -108,6 +108,7 @@
                 'ring (hash-ref ht 'ring 2)
                 'collection (hash-ref ht 'collection #f)
                 'dependencies (hash-ref ht 'dependencies empty)
+                'rt-dependencies (hash-ref ht 'rt-dependencies empty)
                 'implies (hash-ref ht 'implies empty)
                 'modules (hash-ref ht 'modules empty)
                 'conflicts

--- a/official/static.rkt
+++ b/official/static.rkt
@@ -109,6 +109,7 @@
                 'collection (hash-ref ht 'collection #f)
                 'dependencies (hash-ref ht 'dependencies empty)
                 'rt-dependencies (hash-ref ht 'rt-dependencies empty)
+                'license (hash-ref ht 'license #f)
                 'implies (hash-ref ht 'implies empty)
                 'modules (hash-ref ht 'modules empty)
                 'conflicts

--- a/official/update.rkt
+++ b/official/update.rkt
@@ -137,7 +137,7 @@
 (define (update-from-content i)
   (log! "\tgetting package content for ~v" (hash-ref i 'name))
   (match-define-values
-   (checksum module-paths (list dependencies implies collection))
+   (checksum module-paths (list deps rt-deps implies collection))
    (pkg:get-pkg-content
     (pkg:pkg-desc (hash-ref i 'source)
                   #f
@@ -148,13 +148,15 @@
     (λ (get-info)
       (if get-info
         (list (pkg:extract-pkg-dependencies get-info)
+              (pkg:extract-pkg-dependencies get-info #:build-deps? #f)
               (get-info 'implies (λ () empty))
               (get-info 'collection (λ () #f)))
         (list empty empty #f)))))
-                          
+
   (package-begin
    (define* i (hash-set i 'modules module-paths))
-   (define* i (hash-set i 'dependencies dependencies))
+   (define* i (hash-set i 'dependencies deps))
+   (define* i (hash-set i 'rt-dependencies rt-deps))
    (define* i (hash-set i 'implies implies))
    ;; avoid conflation of symbols and strings in JSON
    (define* i (hash-set i 'collection (if (eq? collection 'multi) (list 'multi) collection)))

--- a/official/update.rkt
+++ b/official/update.rkt
@@ -118,10 +118,12 @@
            [(not new-checksum)
             i]
            [(and (equal? new-checksum old-checksum)
-                 ;; update if 'modules or 'implies was not present:
-                 (and (hash-ref i 'modules #f)
-                      (hash-ref i 'implies #f)
-                      (hash-ref i 'collection #f)))
+                 ;; update if essential fields are not present
+                 (and (hash-has-key? i 'modules)
+                      (hash-has-key? i 'implies)
+                      (hash-has-key? i 'collection)
+                      (hash-has-key? i 'rt-dependencies)
+                      (hash-has-key? i 'license)))
             i]
            [else
             (define next-i (update-from-content i))
@@ -137,7 +139,7 @@
 (define (update-from-content i)
   (log! "\tgetting package content for ~v" (hash-ref i 'name))
   (match-define-values
-   (checksum module-paths (list deps rt-deps implies collection))
+   (checksum module-paths (list deps rt-deps license implies collection))
    (pkg:get-pkg-content
     (pkg:pkg-desc (hash-ref i 'source)
                   #f
@@ -149,14 +151,16 @@
       (if get-info
         (list (pkg:extract-pkg-dependencies get-info)
               (pkg:extract-pkg-dependencies get-info #:build-deps? #f)
+              (get-info 'license (λ () #f))
               (get-info 'implies (λ () empty))
               (get-info 'collection (λ () #f)))
-        (list empty empty empty #f)))))
+        (list empty empty #f empty #f)))))
 
   (package-begin
    (define* i (hash-set i 'modules module-paths))
    (define* i (hash-set i 'dependencies deps))
    (define* i (hash-set i 'rt-dependencies rt-deps))
+   (define* i (hash-set i 'license license))
    (define* i (hash-set i 'implies implies))
    ;; avoid conflation of symbols and strings in JSON
    (define* i (hash-set i 'collection (if (eq? collection 'multi) (list 'multi) collection)))

--- a/official/update.rkt
+++ b/official/update.rkt
@@ -156,7 +156,7 @@
               (get-info 'license (λ () missing))
               (get-info 'implies (λ () empty))
               (get-info 'collection (λ () #f)))
-        (list empty empty #f empty #f)))))
+        (list empty empty missing empty #f)))))
 
   (package-begin
    (define* i (hash-set i 'modules module-paths))

--- a/official/update.rkt
+++ b/official/update.rkt
@@ -151,7 +151,7 @@
               (pkg:extract-pkg-dependencies get-info #:build-deps? #f)
               (get-info 'implies (λ () empty))
               (get-info 'collection (λ () #f)))
-        (list empty empty #f)))))
+        (list empty empty empty #f)))))
 
   (package-begin
    (define* i (hash-set i 'modules module-paths))

--- a/official/update.rkt
+++ b/official/update.rkt
@@ -136,6 +136,8 @@
        (package-info-set! pkg-name i)))
     changed?))
 
+(define missing (gensym 'missing))
+
 (define (update-from-content i)
   (log! "\tgetting package content for ~v" (hash-ref i 'name))
   (match-define-values
@@ -151,7 +153,7 @@
       (if get-info
         (list (pkg:extract-pkg-dependencies get-info)
               (pkg:extract-pkg-dependencies get-info #:build-deps? #f)
-              (get-info 'license (λ () #f))
+              (get-info 'license (λ () missing))
               (get-info 'implies (λ () empty))
               (get-info 'collection (λ () #f)))
         (list empty empty #f empty #f)))))
@@ -160,7 +162,10 @@
    (define* i (hash-set i 'modules module-paths))
    (define* i (hash-set i 'dependencies deps))
    (define* i (hash-set i 'rt-dependencies rt-deps))
-   (define* i (hash-set i 'license license))
+   (define* i (hash-set i 'license
+                        (cond
+                          [(eq? license missing) #f]
+                          [else (format "~s" license)])))
    (define* i (hash-set i 'implies implies))
    ;; avoid conflation of symbols and strings in JSON
    (define* i (hash-set i 'collection (if (eq? collection 'multi) (list 'multi) collection)))


### PR DESCRIPTION
One situation where this information is useful is
scraping for license information.
Build-time dependencies don't matter for the situation.