### PR TITLE
Fix invalid source

### DIFF
--- a/official/static.rkt
+++ b/official/static.rkt
@@ -80,27 +80,15 @@
     (define versions-ht
       (hash-set (hash-ref ht 'versions (hash))
                 'default
-                (hasheq 'source (hash-ref ht 'source "")
+                (hasheq 'source (hash-ref ht 'source)
                         'checksum (hash-ref ht 'checksum ""))))
-
-    (define (hash-ref-or ht ks)
-      (or (for/or ([k (in-list ks)])
-            (hash-ref ht k #f))
-          (error 'hash-ref-or "Keys (~v) not found in ~e" ks ht)))
-
-    (define versions-5.3.6
-      (hash-ref-or versions-ht '("5.3.6" default)))
-    (define source-5.3.6
-      (hash-ref versions-5.3.6 'source))
-    (define checksum-5.3.6
-      (hash-ref versions-5.3.6 'checksum))
 
     (hash-set!
      pkg-ht pkg-name
      (hash-set* ht
                 'name pkg-name
-                'source source-5.3.6
-                'checksum checksum-5.3.6
+                'source (hash-ref ht 'source)
+                'checksum (hash-ref ht 'checksum "")
                 'last-updated (hash-ref ht 'last-updated (current-seconds))
                 'last-checked (hash-ref ht 'last-checked (current-seconds))
                 'last-edit (hash-ref ht 'last-edit (current-seconds))


### PR DESCRIPTION
In version 5.3.6 (in 2013), the key 'source and 'checksum were added
to the JSON file, so it's initialized with the information from the
version exception for 5.3.6, falling back to the actual 'source if
the version exception for 5.3.6 doesn't exist.
(https://github.com/racket/pkg-index/commit/5f3be74f915c821361c53bd0ca22049b45c5a6d5)

The issue is that if a package still has the version exception, but
updated 'source to be different from the version exception,
this update will not be reflected in the JSON file in the 'source field
because it prioritizes the version exception for 5.3.6 first.

This PR fixes the issue. Also note that 'source is a mandatory field, so we
don't need to have a fallback value.

(Really, we should have fixed the database if any information is
missing, rather than adding more workaround on the program that queries the
database)

Fixes #34