### PR TITLE
Add search terms using “display names”

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -9,7 +9,7 @@
                "compatibility-lib"
                "net-lib"
                "web-server-lib"
-               "https://github.com/racket/infrastructure-userdb.git#main"
+               ["https://github.com/racket/infrastructure-userdb.git#main" #:version "0.1"]
                "s3-sync"
                "plt-service-monitor"))
 (define build-deps '("rackunit-lib"))

--- a/info.rkt
+++ b/info.rkt
@@ -13,3 +13,5 @@
                "s3-sync"
                "plt-service-monitor"))
 (define build-deps '("rackunit-lib"))
+(define license
+  '(Apache-2.0 OR MIT))

--- a/official/common.rkt
+++ b/official/common.rkt
@@ -4,9 +4,7 @@
          racket/match
          racket/list
          racket/date
-         racket/system
          racket/string
-         web-server/http/id-cookie
          pkg/private/stage
          plt-service-monitor/beat
          infrastructure-userdb

--- a/official/static.rkt
+++ b/official/static.rkt
@@ -14,6 +14,7 @@
          racket/path
          racket/promise
          plt-service-monitor/beat
+         infrastructure-userdb/display-name
          "../basic/main.rkt"
          "common.rkt"
          "notify.rkt"
@@ -262,18 +263,18 @@
                     (hash-set vht 'source_url
                               (package-url->useful-url (hash-ref vht 'source))))))
         'search-terms
-        (let* ([st (hasheq)]
-               [st (for/fold ([st st])
+        (let* ([st (for/fold ([st #hasheq()])
                              ([t (in-list (hash-ref ht 'tags))])
                      (hash-set st (string->symbol t) #t))]
                [st (hash-set
                     st
                     (string->symbol
                      (format "ring:~a" (hash-ref ht 'ring))) #t)]
-               [st (for/fold ([st st])
-                             ([a (in-list (author->list (hash-ref ht 'author)))])
+               [st (for*/fold ([st st])
+                             ([a (in-list (author->list (hash-ref ht 'author)))]
+                              [tag (in-list (display-name-tags (email->display-name a)))])
                      (hash-set
-                      st (string->symbol (format "author:~a" a)) #t))]
+                      st tag #t))]
                [st (if (empty? (hash-ref ht 'tags))
                        (hash-set st ':no-tag: #t)
                        st)]


### PR DESCRIPTION
This patch enables searching by the obfuscated names from
`infrastructure-userdb/display-name`’s `display-name->obfuscated-email`,
which will help to identify package authors without exposing email
addresses to spammers.

Related to https://github.com/racket/racket-pkg-website/issues/77
Related to https://github.com/racket/racket-pkg-website/pull/86
Related to https://github.com/racket/racket-pkg-website/issues/87
Related to https://github.com/racket/racket-pkg-website/pull/88
Related to https://github.com/racket/infrastructure-userdb/pull/1